### PR TITLE
User transaction notifications

### DIFF
--- a/CommerceBankProject/Controllers/NotificationsController.cs
+++ b/CommerceBankProject/Controllers/NotificationsController.cs
@@ -55,14 +55,14 @@ namespace CommerceBankProject.Controllers
 
             if (settings.monthlyBudgetRuleActive)
             {
-                string queryMonthly = @"select top 1 temp.tyear, temp.tmonth,temp.tday, temp.amount  from( 
-                select year([Transaction].onDate) as tyear , month([Transaction].onDate) as tmonth, day([Transaction].onDate) as tday, sum([Transaction].amount) as amount
+                string queryMonthly = @"select top 1 temp.tyear, temp.tmonth, temp.amount  from( 
+                select year([Transaction].onDate) as tyear , month([Transaction].onDate) as tmonth, sum([Transaction].amount) as amount
                 from [Transaction]
                 where [Transaction].transType = 'DR' and customerID = {0}
-                group by year([Transaction].onDate), month([Transaction].onDate),day([transaction].onDate)
+                group by year([Transaction].onDate), month([Transaction].onDate)
                 ) as temp 
-                where amount > {1} and temp.tyear = YEAR(getDate()) and temp.tmonth = MONTH(getDate()) and temp.tday = DAY(getDate())
-                order by temp.tyear DESC, temp.tmonth DESC,temp.tday Desc;";
+                where amount > {1} and temp.tyear = YEAR(getDate()) and temp.tmonth = MONTH(getDate())
+                order by temp.tyear DESC, temp.tmonth DESC;";
 
                 List<MonthlyResult> monthlyList = await _context.MonthlyResult.FromSqlRaw(queryMonthly, user, settings.monthlyBudgetRule).ToListAsync();
 
@@ -80,8 +80,7 @@ namespace CommerceBankProject.Controllers
             {
                 string queryTrans = @"select top 1 *
                 from[Transaction]
-                where transType = 'DR' and balance < {0} and customerID = {1} and Year([transaction].onDate) = YEAR(getDate()) and Month([transaction].onDate) = MONTH(getDate()) and 
-				Day([transaction].onDate) = DAY(getDate())
+                where transType = 'DR' and balance < {0} and customerID = {1} and Year([transaction].onDate) = YEAR(getDate()) and Month([transaction].onDate) = MONTH(getDate())
                 order by onDate desc; ";
 
                 var balanceList = await _context.Transaction.FromSqlRaw(queryTrans, settings.balanceRule, user).ToListAsync();

--- a/CommerceBankProject/Controllers/NotificationsController.cs
+++ b/CommerceBankProject/Controllers/NotificationsController.cs
@@ -53,7 +53,7 @@ namespace CommerceBankProject.Controllers
             where temp.amount > {2} and temp.tyear = YEAR(getDate()) and temp.tmonth = MONTH(getDate())
             order by temp.tyear DESC, temp.tmonth DESC;";
 
-            if (settings.monthlyBudgetRuleActive)
+            if (settings.monthlyBudgetRuleActive && topTransaction.transType == "DR")
             {
                 string queryMonthly = @"select top 1 temp.tyear, temp.tmonth, temp.amount  from( 
                 select year([Transaction].onDate) as tyear , month([Transaction].onDate) as tmonth, sum([Transaction].amount) as amount
@@ -76,7 +76,7 @@ namespace CommerceBankProject.Controllers
                     await _context.SaveChangesAsync();
                 }
             }
-            if (settings.balanceRuleActive)
+            if (settings.balanceRuleActive &&  topTransaction.transType == "DR")
             {
                 string queryTrans = @"select top 1 *
                 from[Transaction]

--- a/CommerceBankProject/Controllers/NotificationsController.cs
+++ b/CommerceBankProject/Controllers/NotificationsController.cs
@@ -47,7 +47,7 @@ namespace CommerceBankProject.Controllers
             query = @"select top 1 temp.tyear, temp.tmonth, temp.amount from( 
             select year([Transaction].onDate) as tyear , month([Transaction].onDate) as tmonth, sum([Transaction].amount) as amount
             from [Transaction]
-            where [Transaction].category = {0} and customerID = {1}
+            where [Transaction].category = {0} and customerID = {1} and [Transaction].transType = 'DR'
             group by ([Transaction].category), year([Transaction].onDate), month([Transaction].onDate)
             ) as temp 
             where temp.amount > {2} and temp.tyear = YEAR(getDate()) and temp.tmonth = MONTH(getDate())
@@ -234,7 +234,7 @@ namespace CommerceBankProject.Controllers
             }
 
 
-            if (settings.timeRuleActive && TimeBetween(topTransaction.onDate, settings.startTimeRule, settings.endTimeRule))
+            if (settings.timeRuleActive && TimeBetween(topTransaction.onDate, settings.startTimeRule, settings.endTimeRule) && topTransaction.transType == "DR")
             {
                 int result = TimeSpan.Compare(settings.startTimeRule, settings.endTimeRule);
                 if (result == 1)

--- a/CommerceBankProject/Controllers/NotificationsController.cs
+++ b/CommerceBankProject/Controllers/NotificationsController.cs
@@ -28,10 +28,252 @@ namespace CommerceBankProject.Controllers
             return View(await _context.Notification.OrderByDescending(n => n.onDate).ToListAsync());
         }
 
-        public void GenerateOnInsertion(Transaction insertedTransaction)
+        public async Task<IActionResult> GenerateOnInsertion(string userID)
         {
-            //does nothing rn
+            
+            var user = userID;
+
+            string topTransQuery = "select top 1 * from[Transaction] where customerID = {0} Order by onDate desc"; //function only called after transaction is inserted so one on top is the needed trans
+
+            var topTransaction = await _context.Transaction.FromSqlRaw(topTransQuery, user).FirstOrDefaultAsync();
+
+
+            string query = "";
+            query = @"Select *
+            from [NotificationSettings]
+            where customerID = {0}";
+            var settings = await _context.NotificationSettings.FromSqlRaw(query, user).FirstOrDefaultAsync();
+
+            query = @"select top 1 temp.tyear, temp.tmonth, temp.amount from( 
+            select year([Transaction].onDate) as tyear , month([Transaction].onDate) as tmonth, sum([Transaction].amount) as amount
+            from [Transaction]
+            where [Transaction].category = {0} and customerID = {1}
+            group by ([Transaction].category), year([Transaction].onDate), month([Transaction].onDate)
+            ) as temp 
+            where temp.amount > {2} and temp.tyear = YEAR(getDate()) and temp.tmonth = MONTH(getDate())
+            order by temp.tyear DESC, temp.tmonth DESC;";
+
+            if (settings.monthlyBudgetRuleActive)
+            {
+                string queryMonthly = @"select top 1 temp.tyear, temp.tmonth,temp.tday, temp.amount  from( 
+                select year([Transaction].onDate) as tyear , month([Transaction].onDate) as tmonth, day([Transaction].onDate) as tday, sum([Transaction].amount) as amount
+                from [Transaction]
+                where [Transaction].transType = 'DR' and customerID = {0}
+                group by year([Transaction].onDate), month([Transaction].onDate),day([transaction].onDate)
+                ) as temp 
+                where amount > {1} and temp.tyear = YEAR(getDate()) and temp.tmonth = MONTH(getDate()) and temp.tday = DAY(getDate())
+                order by temp.tyear DESC, temp.tmonth DESC,temp.tday Desc;";
+
+                List<MonthlyResult> monthlyList = await _context.MonthlyResult.FromSqlRaw(queryMonthly, user, settings.monthlyBudgetRule).ToListAsync();
+
+                foreach (var month in monthlyList)
+                {
+                    DateTime notificationDate = new DateTime(month.tyear, month.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly budget of $" + settings.monthlyBudgetRule.ToString();
+                    Notification notification = new Notification { customerID = user, type = "Monthly Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.balanceRuleActive)
+            {
+                string queryTrans = @"select top 1 *
+                from[Transaction]
+                where transType = 'DR' and balance < {0} and customerID = {1} and Year([transaction].onDate) = YEAR(getDate()) and Month([transaction].onDate) = MONTH(getDate()) and 
+				Day([transaction].onDate) = DAY(getDate())
+                order by onDate desc; ";
+
+                var balanceList = await _context.Transaction.FromSqlRaw(queryTrans, settings.balanceRule, user).ToListAsync();
+
+                foreach (var trans in balanceList)
+                {
+                    string desc = "Your account is below your notification balance of $" + settings.balanceRule.ToString();
+                    Notification notification = new Notification { customerID = user, type = "Low balance", description = desc, onDate = trans.onDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.choresRuleActive && topTransaction.category == "Chores")
+            {
+                var choresList = await _context.MonthlyResult.FromSqlRaw(query, "chores", user, settings.choresRule).ToListAsync();
+
+                foreach (var chores in choresList)
+                {
+                    DateTime notificationDate = new DateTime(chores.tyear, chores.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly chores budget of $" + settings.choresRule.ToString();
+                    Notification notification = new Notification { customerID = user, type = "Chores Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.clothingRuleActive && topTransaction.category == "Clothing")
+            {
+                var clothingList = await _context.MonthlyResult.FromSqlRaw(query, "clothing", user, settings.clothingRule).ToListAsync();
+
+                foreach (var clothing in clothingList)
+                {
+                    DateTime notificationDate = new DateTime(clothing.tyear, clothing.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly clothing budget of $" + settings.clothingRule.ToString();
+                    Notification notification = new Notification { customerID = user, type = "Clothing Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.eatingOutRuleActive && topTransaction.category == "Eating Out")
+            {
+                var eatingOutList = await _context.MonthlyResult.FromSqlRaw(query, "eatingOut", user, settings.eatingOutRule).ToListAsync();
+
+                foreach (var eatingOut in eatingOutList)
+                {
+                    DateTime notificationDate = new DateTime(eatingOut.tyear, eatingOut.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly eating out budget of $" + settings.eatingOutRule.ToString();
+                    Notification notification = new Notification { customerID = user, type = "Eating Out Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.essentialsRuleActive && topTransaction.category == "Essentials")
+            {
+                var essentialsList = await _context.MonthlyResult.FromSqlRaw(query, "Essentials", user, settings.essentialsRule).ToListAsync();
+
+                foreach (var essentials in essentialsList)
+                {
+                    DateTime notificationDate = new DateTime(essentials.tyear, essentials.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly essentials budget of $" + settings.essentialsRule.ToString();
+                    Notification notification = new Notification { customerID = user, type = "Essentials Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.foodRuleActive && topTransaction.category == "Food")
+            {
+                var foodList = await _context.MonthlyResult.FromSqlRaw(query, "Food", user, settings.foodRule).ToListAsync();
+
+                foreach (var food in foodList)
+                {
+                    DateTime notificationDate = new DateTime(food.tyear, food.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly food budget of $" + settings.foodRule.ToString(); ;
+                    Notification notification = new Notification { customerID = user, type = "Food Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.funRuleActive && topTransaction.category == "Fun")
+            {
+                var funList = await _context.MonthlyResult.FromSqlRaw(query, "Fun", user, settings.funRule).ToListAsync();
+
+                foreach (var fun in funList)
+                {
+                    DateTime notificationDate = new DateTime(fun.tyear, fun.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly fun budget of $" + settings.funRule.ToString(); ;
+                    Notification notification = new Notification { customerID = user, type = "Fun Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.gasRuleActive && topTransaction.category == "Gas")
+            {
+                var gasList = await _context.MonthlyResult.FromSqlRaw(query, "Gas", user, settings.gasRule).ToListAsync();
+
+                foreach (var fun in gasList)
+                {
+                    DateTime notificationDate = new DateTime(fun.tyear, fun.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly gas budget of $" + settings.gasRule.ToString(); ;
+                    Notification notification = new Notification { customerID = user, type = "Gas Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.phoneRuleActive && topTransaction.category == "Phone")
+            {
+                var phoneList = await _context.MonthlyResult.FromSqlRaw(query, "Phone", user, settings.phoneRule).ToListAsync();
+
+                foreach (var phone in phoneList)
+                {
+                    DateTime notificationDate = new DateTime(phone.tyear, phone.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly phone budget of $" + settings.phoneRule.ToString(); ;
+                    Notification notification = new Notification { customerID = user, type = "Phone Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            if (settings.otherRuleActive && topTransaction.category == "Other")
+            {
+                var otherList = await _context.MonthlyResult.FromSqlRaw(query, "Other", user, settings.otherRule).ToListAsync();
+
+                foreach (var other in otherList)
+                {
+                    DateTime notificationDate = new DateTime(other.tyear, other.tmonth, 1);
+                    notificationDate = notificationDate.AddMonths(1);
+                    string desc = "You have exceeded your monthly other budget of $" + settings.otherRule.ToString(); ;
+                    Notification notification = new Notification { customerID = user, type = "Other Budget", description = desc, onDate = notificationDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+
+
+
+            bool TimeBetween(DateTime datetime, TimeSpan start, TimeSpan end) //checking if just inserted transaction is between notif times
+            {
+                // convert datetime to a TimeSpan
+                TimeSpan now = datetime.TimeOfDay;
+                // see if start comes before end
+                if (start < end)
+                    return start <= now && now <= end;
+                // start is after end, so do the inverse comparison
+                return !(end < now && now < start);
+            }
+
+
+            if (settings.timeRuleActive && TimeBetween(topTransaction.onDate, settings.startTimeRule, settings.endTimeRule))
+            {
+                int result = TimeSpan.Compare(settings.startTimeRule, settings.endTimeRule);
+                if (result == 1)
+                {
+                    query = @"select top 1*
+                    from[Transaction]
+                    where (CAST(onDate as time) >= {0} or CAST(onDate as time) < {1})
+                    and customerID = {2} and [Transaction].transType = 'DR' order by onDate desc;";
+                }
+                else
+                {
+                    query = @"select top 1 *
+                    from[Transaction]
+                    where (CAST(onDate as time) >= {0} and CAST(onDate as time) < {1})
+                    and customerID = {2} and [Transaction].transType = 'DR' order by ondate desc;";
+                }
+
+                var timeList = await _context.Transaction.FromSqlRaw(query, settings.startTimeRule, settings.endTimeRule, user).ToListAsync();
+
+                string displayStartTime = new DateTime().Add(settings.startTimeRule).ToString("hh:mm tt");
+                string displayEndTime = new DateTime().Add(settings.endTimeRule).ToString("hh:mm tt");
+
+                foreach (var time in timeList)
+                {
+                    string desc = "You have a transaction out of your time frame of " + displayStartTime + " to " + displayEndTime;
+                    Notification notification = new Notification { customerID = user, type = "Time frame", description = desc, onDate = time.onDate, read = false, saved = false };
+                    await _context.AddAsync(notification);
+                    await _context.SaveChangesAsync();
+                }
+            }
+
+            return RedirectToAction("Index", "TransactionsController");
+
+
+
+
         }
+    
 
         [Authorize]
         public async Task<IActionResult> Generate()
@@ -101,7 +343,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.choresRuleActive)
             {
-                var choresList = await _context.MonthlyResult.FromSqlRaw(query, "chores", user.customerID, settings.choresRule).ToListAsync();
+                var choresList = await _context.MonthlyResult.FromSqlRaw(query, "Chores", user.customerID, settings.choresRule).ToListAsync();
 
                 foreach (var chores in choresList)
                 {
@@ -115,7 +357,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.clothingRuleActive)
             {
-                var clothingList = await _context.MonthlyResult.FromSqlRaw(query, "clothing", user.customerID, settings.clothingRule).ToListAsync();
+                var clothingList = await _context.MonthlyResult.FromSqlRaw(query, "Clothing", user.customerID, settings.clothingRule).ToListAsync();
 
                 foreach (var clothing in clothingList)
                 {
@@ -129,7 +371,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.eatingOutRuleActive)
             {
-                var eatingOutList = await _context.MonthlyResult.FromSqlRaw(query, "eatingOut", user.customerID, settings.eatingOutRule).ToListAsync();
+                var eatingOutList = await _context.MonthlyResult.FromSqlRaw(query, "Eating Out", user.customerID, settings.eatingOutRule).ToListAsync();
 
                 foreach (var eatingOut in eatingOutList)
                 {
@@ -143,7 +385,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.essentialsRuleActive)
             {
-                var essentialsList = await _context.MonthlyResult.FromSqlRaw(query, "essentials", user.customerID, settings.essentialsRule).ToListAsync();
+                var essentialsList = await _context.MonthlyResult.FromSqlRaw(query, "Essentials", user.customerID, settings.essentialsRule).ToListAsync();
 
                 foreach (var essentials in essentialsList)
                 {
@@ -157,7 +399,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.foodRuleActive)
             {
-                var foodList = await _context.MonthlyResult.FromSqlRaw(query, "food", user.customerID, settings.foodRule).ToListAsync();
+                var foodList = await _context.MonthlyResult.FromSqlRaw(query, "Food", user.customerID, settings.foodRule).ToListAsync();
 
                 foreach (var food in foodList)
                 {
@@ -171,7 +413,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.funRuleActive)
             {
-                var funList = await _context.MonthlyResult.FromSqlRaw(query, "fun", user.customerID, settings.funRule).ToListAsync();
+                var funList = await _context.MonthlyResult.FromSqlRaw(query, "Fun", user.customerID, settings.funRule).ToListAsync();
 
                 foreach (var fun in funList)
                 {
@@ -185,7 +427,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.gasRuleActive)
             {
-                var gasList = await _context.MonthlyResult.FromSqlRaw(query, "gas", user.customerID, settings.gasRule).ToListAsync();
+                var gasList = await _context.MonthlyResult.FromSqlRaw(query, "Gas", user.customerID, settings.gasRule).ToListAsync();
 
                 foreach (var fun in gasList)
                 {
@@ -199,7 +441,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.phoneRuleActive)
             {
-                var phoneList = await _context.MonthlyResult.FromSqlRaw(query, "phone", user.customerID, settings.phoneRule).ToListAsync();
+                var phoneList = await _context.MonthlyResult.FromSqlRaw(query, "Phone", user.customerID, settings.phoneRule).ToListAsync();
 
                 foreach (var phone in phoneList)
                 {
@@ -213,7 +455,7 @@ namespace CommerceBankProject.Controllers
             }
             if (settings.otherRuleActive)
             {
-                var otherList = await _context.MonthlyResult.FromSqlRaw(query, "other", user.customerID, settings.otherRule).ToListAsync();
+                var otherList = await _context.MonthlyResult.FromSqlRaw(query, "Other", user.customerID, settings.otherRule).ToListAsync();
 
                 foreach (var other in otherList)
                 {

--- a/CommerceBankProject/Controllers/TransactionsController.cs
+++ b/CommerceBankProject/Controllers/TransactionsController.cs
@@ -115,6 +115,7 @@ namespace CommerceBankProject.Controllers
             Transaction trans = new Transaction();
             t.userAccounts = actListSetup;
             t.transaction = trans;
+            //trans.transType = "CR";
             return View("Create", t);
 
         }
@@ -126,7 +127,7 @@ namespace CommerceBankProject.Controllers
         [Authorize]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(string tranActFilter,decimal amount,string description,string category)
+        public async Task<IActionResult> Create(string tranActFilter,string transType,decimal amount,string description,string category)
         {
             
             
@@ -134,14 +135,13 @@ namespace CommerceBankProject.Controllers
                 string userID = claim.Value;
                 var user = await _context.Users.Where(u => u.Id == userID).FirstOrDefaultAsync();
                 Transaction t = new Transaction();
-
                 t.customerID = user.customerID;
                 t.actID = tranActFilter;
-                t.transType = "DR";
+                t.transType = transType;
                 t.amount = amount;
                 t.description = description;
                 t.userEntered = true;
-                t.category = category;
+                //t.category = category;
                 t.onDate = DateTime.Now;
 
 
@@ -156,10 +156,12 @@ namespace CommerceBankProject.Controllers
                 
                 if (t.transType == "DR")
                 {
+                    t.category = category;
                     t.balance = userBalance - t.amount;
                 }
                 else
                 {
+                    t.category = "Income";
                     t.balance = userBalance + t.amount;
 
                 }

--- a/CommerceBankProject/Controllers/TransactionsController.cs
+++ b/CommerceBankProject/Controllers/TransactionsController.cs
@@ -126,7 +126,7 @@ namespace CommerceBankProject.Controllers
         [Authorize]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(string tranActFilter,string transType,decimal amount,string description,string category)
+        public async Task<IActionResult> Create(string tranActFilter,decimal amount,string description,string category)
         {
             
             
@@ -137,7 +137,7 @@ namespace CommerceBankProject.Controllers
 
                 t.customerID = user.customerID;
                 t.actID = tranActFilter;
-                t.transType = transType;
+                t.transType = "DR";
                 t.amount = amount;
                 t.description = description;
                 t.userEntered = true;
@@ -167,10 +167,11 @@ namespace CommerceBankProject.Controllers
 
                 _context.Add(t);
                 await _context.SaveChangesAsync();
-                //NotificationsController temp = new NotificationsController(_context);
-                //temp.GenerateOnInsertion(t);
-                return RedirectToAction(nameof(Index));
-            }
+            NotificationsController temp = new NotificationsController(_context);
+            await temp.GenerateOnInsertion(user.customerID);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
             
         
 

--- a/CommerceBankProject/Views/Transactions/Create.cshtml
+++ b/CommerceBankProject/Views/Transactions/Create.cshtml
@@ -32,22 +32,34 @@
                         </select>
                     </div>
                 </div>
-                
+                <div class="text-center ml-3">
+                    <label for="transType">Type</label>
+                    <div>
+                        <select id="transType" name="transType" onchange="ShowHideDiv()">
+                            <option value="CR" selected>Deposit</option>
+                            <option value="DR">Withdraw</option>
+                        </select>
+                    </div>
+                </div>
             </div>
             <div class="text-center mb-3">
-                <label for="category">Category</label>
+                <label for="category" id="categoryLabel" style="display:none">Category</label>
                 <div>
-                    <select id="category" name="category" class="mb-3">
-                        <option value="Other" selected>Other</option>
-                        <option value="Clothing">Clothing</option>
-                        <option value="Chores">Chores</option>
-                        <option value="Eating Out">Eating Out</option>
-                        <option value="Essentials">Essentials</option>
-                        <option value="Food">Food</option>
-                        <option value="Fun">Fun</option>
-                        <option value="Gas">Gas</option>
-                        <option value="Phone">Phone</option>
-                    </select>
+                    
+                 <select id="category" name="category" class="mb-3" style="display: none">
+                      <option value="Other" selected>Other</option>
+                      <option value="Clothing">Clothing</option>
+                      <option value="Chores">Chores</option>
+                      <option value="Eating Out">Eating Out</option>
+                      <option value="Essentials">Essentials</option>
+                      <option value="Food">Food</option>
+                      <option value="Fun">Fun</option>
+                      <option value="Gas">Gas</option>
+                      <option value="Phone">Phone</option>
+                  </select>
+                    
+
+                    
                 </div>
             </div>
 
@@ -78,4 +90,5 @@
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+    
 }

--- a/CommerceBankProject/Views/Transactions/Create.cshtml
+++ b/CommerceBankProject/Views/Transactions/Create.cshtml
@@ -32,15 +32,7 @@
                         </select>
                     </div>
                 </div>
-                <div class="text-center ml-3">
-                    <label for="transType">Type</label>
-                    <div>
-                        <select id="transType" name="transType">
-                            <option value="DR">Withdrawal</option>
-                            <option value="CR">Deposit</option>
-                        </select>
-                    </div>
-                </div>
+                
             </div>
             <div class="text-center mb-3">
                 <label for="category">Category</label>

--- a/CommerceBankProject/wwwroot/js/site.js
+++ b/CommerceBankProject/wwwroot/js/site.js
@@ -7,7 +7,6 @@
 function trackSlider(slide, output) {
     document.getElementById(output).value = slide.value;
 }
-
 function toggleEnabled(rangeName) {
     var ele = document.getElementById(rangeName);
     if (ele.disabled) {
@@ -47,5 +46,12 @@ function toggleHidden(btn, displayName) {
     inputs.classList.toggle("open");
 }
 
+function ShowHideDiv() {
+    var categoryLabel = document.getElementById("categoryLabel");
+    var categoryDropDown = document.getElementById("category");
+    var transType = document.getElementById("transType");
+    categoryDropDown.style.display = transType.value == "DR" ? "block" : "none";
+    categoryLabel.style.display = transType.value == "DR" ? "block" : "none";
+}
 
 

--- a/ProjectUnitTests/Controllers/TestTransactionsController.cs
+++ b/ProjectUnitTests/Controllers/TestTransactionsController.cs
@@ -190,7 +190,7 @@ namespace ProjectUnitTests
 
                 controller = new TransactionsController(context);
 
-                var result = await controller.Create("222222222","CR", 978.04m, "Description", "Phone");
+                var result = await controller.Create("222222222", 978.04m, "Description", "Phone");
                 Assert.IsType<RedirectToActionResult>(result);
 
                 var viewRes = result as RedirectToActionResult;

--- a/ProjectUnitTests/Controllers/TestTransactionsController.cs
+++ b/ProjectUnitTests/Controllers/TestTransactionsController.cs
@@ -190,7 +190,7 @@ namespace ProjectUnitTests
 
                 controller = new TransactionsController(context);
 
-                var result = await controller.Create("222222222", 978.04m, "Description", "Phone");
+                var result = await controller.Create("222222222","CR", 978.04m, "Description", "Phone");
                 Assert.IsType<RedirectToActionResult>(result);
 
                 var viewRes = result as RedirectToActionResult;


### PR DESCRIPTION
Create transaction page now dynamic. When the transaction is a withdraw they will have category selection, but when it is a deposit they do not see the categories and it is set to "Income" as the category.

As for the rules themselves, I've tried to reduce spam as much as possible by limiting all rules to DR(don't think CR makes sense for any of the rules), checking if the new transaction is within their time notif before calling the time query, only calling queries that match the new transaction category and various other checks to reduce spam.

They all seem to be working from what I've tested, but if anyone feels like doing some additional testing that would be helpful!